### PR TITLE
Added new statsd_additional_options_raw for special options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,7 @@ statsd_graphite:
 #  { "legacyNamespace": false }
 
 statsd_additional_options: {}       # Setup additional options
+statsd_additional_options_raw: {}       # Setup additional options without piping values trough 'to_nice_json' filter
+
+# Extra NPM dependencies. For example if your config.js depends on to something
+statsd_extra_dependencies: []

--- a/templates/statsd.js.j2
+++ b/templates/statsd.js.j2
@@ -125,4 +125,7 @@ Optional Variables:
 {% for name, value in statsd_additional_options.items() %}
 , {{name}}: {{value|to_nice_json}}
 {% endfor %}
+{% for name, value in statsd_additional_options_raw.items() %}
+, {{name}}: {{value}}
+{% endfor %}
 }


### PR DESCRIPTION
To be able to set special javascript based configurations,
created new statsd_additional_options_raw what values doesn't get
piped trough 'to_nice_json' filter.
